### PR TITLE
Fix deprecated by adding the public value to class constructor

### DIFF
--- a/libs/twtxt.php
+++ b/libs/twtxt.php
@@ -25,6 +25,7 @@ class TwtxtFile {
 class Twt {
 	public $originalTwtStr;
 	public $hash;
+	public $timestamp;
 	public $fullDate;
 	public $displayDate;
 	public $content;


### PR DESCRIPTION
To remove 

```
Deprecated: Creation of dynamic property Twt::$timestamp is deprecated in timeline/libs/twtxt.php on line 443
```