### PR TITLE
fix for the "Cannot modify header information..." warning on login page.

### DIFF
--- a/views/login.php
+++ b/views/login.php
@@ -3,19 +3,18 @@ require_once("partials/base.php");
 
 $title = "Login - ".$title;
 
-include 'partials/header.php';
-?>
-
-<?php
     // Password comes from libs/session.php
     if (isset($_SESSION['password'])) {
         if ($_SESSION['password'] == $password) {
             header("Location: .");
+            include 'partials/header.php';
             die();
         }
     }
 
-    else { ?>
+    else { 
+      include 'partials/header.php';
+?>
         <center>
         <h2>Enter password or TOTP</h2>
         <form method="post" action="" id="login_form">


### PR DESCRIPTION
fix for the `Cannot modify header information - headers already sent by [...]/header.php` warning on login page. as mentioned in #18 section 3.