### PR TITLE
Fixes

### DIFF
--- a/views/following.php
+++ b/views/following.php
@@ -18,7 +18,7 @@ include 'partials/header.php';
             <!-- <th></th> -->
             <th>Nick</th>
             <th>URL</th>
-            <?php if($_SESSION['password']=="$password") { ?>
+            <?php if(isset($_SESSION['password']) && $_SESSION['password']=="$password") { ?>
                 <th>Time ago</th>
             <?php } ?>
         </tr>
@@ -33,7 +33,7 @@ include 'partials/header.php';
                 <!-- <a href="?remove_url=<?= $currentFollower[1] ?>">Remove</a> -->
                 <!-- <?php // } ?> -->
             </td>
-            <?php if($_SESSION['password']=="$password") { ?>
+            <?php if(isset($_SESSION['password']) && $_SESSION['password']=="$password") { ?>
             <td>
                 <?php
                     // Test first if URL is a valid feed:

--- a/views/replies.php
+++ b/views/replies.php
@@ -1,4 +1,3 @@
-
 <?php
 
 if (!empty($_GET['url'])) { // Show twts for some user (Profile view)


### PR DESCRIPTION
quick fixes for:
- the `timeline/following` page complaining about an undefined array key "password".
![undefined array key "password" warning](https://github.com/user-attachments/assets/6b65aa68-2de0-4bfe-b690-7ea9e61a6b7c)
- the `timeline/replies?url=...` complaining about inability to start a session after headers being sent beforehand, caused by an empty line at the start of the `views/replies.php` file.
![headers already sent warning](https://github.com/user-attachments/assets/a179fc17-7d4f-4d7f-984d-c183818d2146)