### PR TITLE
Fix Warning in the `Webfinger lookup` input box on the `Add Feed` page

### DIFF
--- a/partials/webfinger_lookup.php
+++ b/partials/webfinger_lookup.php
@@ -15,6 +15,7 @@ $wf_acct = "";
 $wf_nick = "";
 $wf_url = "";
 $wf_error = "";
+$wf_request = "";
 
 if(isset($_POST['submit'])) { 
 	$wf_request = $_POST["webfinger"];


### PR DESCRIPTION
fix for #31 